### PR TITLE
Don't need the second type conversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,5 +49,5 @@ func main() {
 	dnsUint := ipv4Uint + 2
 	buff := make(net.IP, 4)
 	binary.BigEndian.PutUint32(buff, dnsUint)
-	fmt.Printf("%v\n", net.IP(buff))
+	fmt.Printf("%v\n", buff)
 }


### PR DESCRIPTION
buff is already of type `net.IP`